### PR TITLE
Column concatenation in .pdb file when residue index > 999

### DIFF
--- a/af2_initial_guess/interfaceAF2predict.py
+++ b/af2_initial_guess/interfaceAF2predict.py
@@ -441,6 +441,10 @@ def input_check( pdbfile, tag ):
         if not splits[0] == "ATOM": continue
 
         if splits[2] == 'CA':
+            # Check if chain and residue index columns were concatenated
+            if len(splits[4])>1:
+                splits.insert(5, splits[4][1:])
+                splits[4] = splits[4][0]
             # Only checking residue index at CA atom
             residx = splits[5]
             if residx in seen_indices:


### PR DESCRIPTION
I was running RFdiffusion with dl_binder_design pipeline when suddenly I started randomly getting error about having non-unique residue indices. It seemed strange at first, as the output file from RFdiffusion was intact (chain A - binder, chain B - target, each residue index is unique). However, this is what happens when the residue index > 999:

> ATOM  15333 2HE  MET B 999      29.180 -52.646 -15.485  1.00  0.00           H  
ATOM  15334 3HE  MET B 999      27.618 -52.456 -14.654  1.00  0.00           H  
ATOM  15335  N GLY B1000      26.291 -58.439 -16.471  1.00  0.00           N  
ATOM  15336  CA  GLY B1000      26.746 -59.823 -16.438  1.00  0.00           C  

At res.index >= 1000, columns 5 (chain) and 6 (res.index) are concatenated, so the `input_check` function inside `interfaceAF2predict.py` script is checking the wrong column at this point.

I guess this is linked to .pdb format itself. I implemented a small fix to get around this.